### PR TITLE
Misc changes

### DIFF
--- a/src/core/react-query/webui/queries.ts
+++ b/src/core/react-query/webui/queries.ts
@@ -51,6 +51,7 @@ export const useSeriesFileSummaryQuery = (seriesId: number, params: SeriesFileSu
     queryKey: ['webui', 'series-file-summary', seriesId, params],
     queryFn: () => axios.get(`WebUI/Series/${seriesId}/FileSummary`, { params }),
     enabled,
+    placeholderData: prevData => prevData,
   });
 
 export const useSeriesOverviewQuery = (seriesId: number, enabled = true) =>

--- a/src/pages/collection/series/SeriesCredits.tsx
+++ b/src/pages/collection/series/SeriesCredits.tsx
@@ -106,13 +106,13 @@ const SeriesCredits = () => {
     Staff: getUniqueDescriptions(castByType.Staff),
   }), [castByType]);
 
-  const [descriptionFilter, setDescriptionFilter] = useState<string[]>([]);
+  const [descriptionFilter, setDescriptionFilter] = useState<Set<string>>(new Set());
 
   const filteredCast = useMemo(() => (castByType[mode].filter(p => (
     (debouncedSearch === ''
       || !!(cleanString(p?.Character?.Name).match(debouncedSearch))
       || !!(cleanString(p?.Staff?.Name).match(debouncedSearch)))
-    && !descriptionFilter.includes(p?.RoleDetails)
+    && !descriptionFilter.has(p?.RoleDetails)
   )).sort((a, b) => {
     if (a[mode].Name > b[mode].Name) return 1;
     if (a[mode].Name < b[mode].Name) return -1;
@@ -121,17 +121,16 @@ const SeriesCredits = () => {
 
   useEffect(() => {
     setSearch('');
-    setDescriptionFilter([]);
+    setDescriptionFilter(new Set());
   }, [mode]);
 
   const handleFilterChange = useEventCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const { checked: active, id: description } = event.target;
-    if (active && descriptionFilter.includes(description)) {
-      setDescriptionFilter(descriptionFilter.filter(d => d !== description));
-    }
-    if (!active && !descriptionFilter.includes(description)) {
-      setDescriptionFilter([...descriptionFilter, description]);
-    }
+    const { id: description } = event.target;
+    setDescriptionFilter((prevState) => {
+      const newState = new Set(prevState);
+      if (!newState.delete(description)) newState.add(description);
+      return newState;
+    });
   });
 
   if (!seriesId) return null;
@@ -170,7 +169,7 @@ const SeriesCredits = () => {
                   label={desc}
                   key={desc}
                   id={desc}
-                  isChecked={!descriptionFilter.includes(desc)}
+                  isChecked={!descriptionFilter.has(desc)}
                   onChange={handleFilterChange}
                 />
               ))}
@@ -225,7 +224,7 @@ const SeriesCredits = () => {
         <div className="flex h-[6.125rem] items-center justify-between rounded-lg border border-panel-border bg-panel-background-transparent px-6 py-4">
           <div className="text-xl font-semibold">
             Credits |&nbsp;
-            {(debouncedSearch !== '' || descriptionFilter.length !== 0) && (
+            {(debouncedSearch !== '' || descriptionFilter.size > 0) && (
               <>
                 <span className="text-panel-text-important">
                   {filteredCast.length}

--- a/src/pages/collection/series/SeriesCredits.tsx
+++ b/src/pages/collection/series/SeriesCredits.tsx
@@ -87,9 +87,7 @@ const getUniqueDescriptions = (castList: SeriesCast[]) => [...new Set(castList.m
 
 const StaffPanelVirtualizer = ({ castArray, mode }: { castArray: SeriesCast[], mode: ModeType }) => {
   const { scrollRef } = useOutletContext<{ scrollRef: React.RefObject<HTMLDivElement> }>();
-  const cardSize = { x: 466.5, y: 174 };
-
-  const getLaneOffset = (lane: number) => ((cardSize.x * lane) + (lane > 0 ? 24 * lane : 0));
+  const cardSize = { x: 466.5, y: 174, gap: 24 };
 
   const rowVirtualizer = useVirtualizer({
     count: castArray.length,
@@ -97,7 +95,7 @@ const StaffPanelVirtualizer = ({ castArray, mode }: { castArray: SeriesCast[], m
     estimateSize: () => cardSize.y,
     overscan: 30, // Greater than the norm as lanes aren't taken into account
     lanes: 3,
-    gap: 24,
+    gap: cardSize.gap,
   });
 
   return (
@@ -107,7 +105,7 @@ const StaffPanelVirtualizer = ({ castArray, mode }: { castArray: SeriesCast[], m
           key={virtualRow.key}
           className="absolute top-0"
           style={{
-            left: getLaneOffset(virtualRow.lane),
+            left: virtualRow.lane * (cardSize.x + cardSize.gap),
             width: cardSize.x,
             height: cardSize.y,
             transform: `translateY(${virtualRow.start}px)`,

--- a/src/pages/collection/series/SeriesFileSummary.tsx
+++ b/src/pages/collection/series/SeriesFileSummary.tsx
@@ -42,6 +42,16 @@ const Header = ({ fetchingState, ranges }: HeaderProps) => (
   </div>
 );
 
+const SummaryGroupRow = ({ label, value }: { label: string, value: string }) => (
+  <div className="flex gap-x-12">
+    <div className="w-20 shrink-0 font-semibold">
+      {label}
+    </div>
+    <div className="max-w-[33rem] break-words">
+      {value}
+    </div>
+  </div>
+);
 const SummaryGroup = React.memo(
   ({ fetchingState, group }: { group: WebuiSeriesFileSummaryGroupType, fetchingState: boolean }) => {
     const sizes = useMemo(() => {
@@ -123,26 +133,16 @@ const SummaryGroup = React.memo(
         <div className="flex text-xl font-semibold">
           <Header ranges={group.RangeByType} fetchingState={fetchingState} />
         </div>
-        <div className="flex">
-          <div className="flex grow flex-col gap-y-4 font-semibold">
-            <span>Group</span>
-            <span>Video</span>
-            <span>Location</span>
+        <div className="flex gap-x-[4.5rem]">
+          <div className="flex flex-col gap-y-2">
+            <SummaryGroupRow label="Group" value={groupDetails} />
+            <SummaryGroupRow label="Video" value={videoDetails} />
+            <SummaryGroupRow label="Location" value={locationDetails} />
           </div>
-          <div className="flex max-w-[60%] grow-[2] flex-col gap-y-4">
-            <span>{groupDetails}</span>
-            <span>{videoDetails}</span>
-            <span>{locationDetails}</span>
-          </div>
-          <div className="flex grow flex-col gap-y-4 font-semibold">
-            <span>Total</span>
-            <span>Audio</span>
-            <span>Subtitles</span>
-          </div>
-          <div className="flex max-w-[60%] grow-[2] flex-col gap-y-4">
-            <span>{sizes}</span>
-            <span>{audioDetails}</span>
-            <span>{subtitleDetails}</span>
+          <div className="flex flex-col gap-y-2">
+            <SummaryGroupRow label="Total" value={sizes} />
+            <SummaryGroupRow label="Audio" value={audioDetails} />
+            <SummaryGroupRow label="Subtitles" value={subtitleDetails} />
           </div>
         </div>
       </div>

--- a/src/pages/collection/series/SeriesFileSummary.tsx
+++ b/src/pages/collection/series/SeriesFileSummary.tsx
@@ -32,118 +32,123 @@ const HeaderFragment = ({ range, title }) => {
   );
 };
 
-type HeaderProps = { ranges: WebuiSeriesFileSummaryGroupRangeByType };
-const Header = ({ ranges }: HeaderProps) => (
+type HeaderProps = { ranges: WebuiSeriesFileSummaryGroupRangeByType, fetchingState: boolean };
+const Header = ({ fetchingState, ranges }: HeaderProps) => (
   <div className="flex gap-x-2">
     <HeaderFragment title={ranges?.Normal?.Range.length > 2 ? 'Episodes' : 'Episode'} range={ranges?.Normal?.Range} />
     <HeaderFragment title={ranges?.Normal?.Range.length > 2 ? 'Specials' : 'Special'} range={ranges?.Special?.Range} />
     {map(omit(ranges, ['Normal', 'Special']), (item, key) => <HeaderFragment title={key} range={item.Range} />)}
+    {fetchingState && <Icon path={mdiLoading} spin size={1.5} />}
   </div>
 );
 
-const SummaryGroup = React.memo(({ group }: { group: WebuiSeriesFileSummaryGroupType }) => {
-  const sizes = useMemo(() => {
-    const sizeMap: Record<string, { size: number, count: number }> = {};
-    forEach(group.RangeByType, (item, key) => {
-      let idx = 'Other';
-      if (key === 'Normal') {
-        idx = item.Count > 1 ? 'Episodes' : 'Episode';
-      } else if (key === 'Special') {
-        idx = item.Count > 1 ? 'Specials' : 'Special';
-      }
+const SummaryGroup = React.memo(
+  ({ fetchingState, group }: { group: WebuiSeriesFileSummaryGroupType, fetchingState: boolean }) => {
+    const sizes = useMemo(() => {
+      const sizeMap: Record<string, { size: number, count: number }> = {};
+      forEach(group.RangeByType, (item, key) => {
+        let idx = 'Other';
+        if (key === 'Normal') {
+          idx = item.Count > 1 ? 'Episodes' : 'Episode';
+        } else if (key === 'Special') {
+          idx = item.Count > 1 ? 'Specials' : 'Special';
+        }
 
-      if (!sizeMap[idx]) {
-        sizeMap[idx] = { size: 0, count: 0 };
-      }
-      sizeMap[idx].size += item.FileSize;
-      sizeMap[idx].count += item.Count;
-    });
+        if (!sizeMap[idx]) {
+          sizeMap[idx] = { size: 0, count: 0 };
+        }
+        sizeMap[idx].size += item.FileSize;
+        sizeMap[idx].count += item.Count;
+      });
 
-    return map(sizeMap, (size, name) => (
-      `${size.count} ${name} (${prettyBytes(size.size, { binary: true })})`
-    )).join(' | ');
-  }, [group]);
+      return map(sizeMap, (size, name) => (
+        `${size.count} ${name} (${prettyBytes(size.size, { binary: true })})`
+      )).join(' | ');
+    }, [group]);
 
-  const groupDetails = useMemo(() => (group.GroupName ? `${group.GroupName} (${group.GroupNameShort})` : '-'), [group]);
-  const videoDetails = useMemo(() => {
-    const conditions: string[] = [];
-    if (group.FileSource) {
-      conditions.push(group.FileSource.replace('BluRay', 'Blu-Ray'));
-    }
-    if (group.FileVersion) {
-      conditions.push(`v${group.FileVersion}`);
-    }
-    if (group.VideoBitDepth) {
-      conditions.push(`${group.VideoBitDepth}-bit`);
-    }
-    if (group.VideoResolution) {
-      conditions.push(`${group.VideoResolution} (${group.VideoWidth}x${group.VideoHeight})`);
-    }
-    if (group.VideoCodecs) {
-      conditions.push(group.VideoCodecs);
-    }
-    return conditions.length ? conditions.join(' | ') : '-';
-  }, [group]);
-  const audioDetails = useMemo(() => {
-    const conditions: string[] = [];
-    if (group.AudioCodecs) {
-      conditions.push(group.AudioCodecs.toUpperCase());
-    }
-    if (group.AudioLanguages) {
-      if (group.AudioStreamCount !== undefined) {
-        conditions.push(`Multi Audio (${group.AudioLanguages.join(', ')})`);
-      } else {
-        conditions.push(group.AudioLanguages.join(', '));
+    const groupDetails = useMemo(() => (group.GroupName ? `${group.GroupName} (${group.GroupNameShort})` : '-'), [
+      group,
+    ]);
+    const videoDetails = useMemo(() => {
+      const conditions: string[] = [];
+      if (group.FileSource) {
+        conditions.push(group.FileSource.replace('BluRay', 'Blu-Ray'));
       }
-    }
-    return conditions.length ? conditions.join(' | ') : '-';
-  }, [group]);
-  const subtitleDetails = useMemo(() => {
-    const conditions: string[] = [];
-    if (group.SubtitleCodecs) {
-      conditions.push(group.SubtitleCodecs.toUpperCase());
-    }
-    if (group.SubtitleLanguages) {
-      if (group.SubtitleStreamCount !== undefined) {
-        conditions.push(`Multi Audio (${group.SubtitleLanguages.join(', ')})`);
-      } else {
-        conditions.push(group.SubtitleLanguages.join(', '));
+      if (group.FileVersion) {
+        conditions.push(`v${group.FileVersion}`);
       }
-    }
-    return conditions.length ? conditions.join(' | ') : '-';
-  }, [group]);
-  const locationDetails = group.FileLocation ?? '-';
+      if (group.VideoBitDepth) {
+        conditions.push(`${group.VideoBitDepth}-bit`);
+      }
+      if (group.VideoResolution) {
+        conditions.push(`${group.VideoResolution} (${group.VideoWidth}x${group.VideoHeight})`);
+      }
+      if (group.VideoCodecs) {
+        conditions.push(group.VideoCodecs);
+      }
+      return conditions.length ? conditions.join(' | ') : '-';
+    }, [group]);
+    const audioDetails = useMemo(() => {
+      const conditions: string[] = [];
+      if (group.AudioCodecs) {
+        conditions.push(group.AudioCodecs.toUpperCase());
+      }
+      if (group.AudioLanguages) {
+        if (group.AudioStreamCount !== undefined) {
+          conditions.push(`Multi Audio (${group.AudioLanguages.join(', ')})`);
+        } else {
+          conditions.push(group.AudioLanguages.join(', '));
+        }
+      }
+      return conditions.length ? conditions.join(' | ') : '-';
+    }, [group]);
+    const subtitleDetails = useMemo(() => {
+      const conditions: string[] = [];
+      if (group.SubtitleCodecs) {
+        conditions.push(group.SubtitleCodecs.toUpperCase());
+      }
+      if (group.SubtitleLanguages) {
+        if (group.SubtitleStreamCount !== undefined) {
+          conditions.push(`Multi Audio (${group.SubtitleLanguages.join(', ')})`);
+        } else {
+          conditions.push(group.SubtitleLanguages.join(', '));
+        }
+      }
+      return conditions.length ? conditions.join(' | ') : '-';
+    }, [group]);
+    const locationDetails = group.FileLocation ?? '-';
 
-  return (
-    <div className="flex flex-col gap-y-6 rounded border border-panel-border bg-panel-background-transparent p-6">
-      <div className="flex text-xl font-semibold">
-        <Header ranges={group.RangeByType} />
+    return (
+      <div className="flex flex-col gap-y-6 rounded border border-panel-border bg-panel-background-transparent p-6">
+        <div className="flex text-xl font-semibold">
+          <Header ranges={group.RangeByType} fetchingState={fetchingState} />
+        </div>
+        <div className="flex">
+          <div className="flex grow flex-col gap-y-4 font-semibold">
+            <span>Group</span>
+            <span>Video</span>
+            <span>Location</span>
+          </div>
+          <div className="flex max-w-[60%] grow-[2] flex-col gap-y-4">
+            <span>{groupDetails}</span>
+            <span>{videoDetails}</span>
+            <span>{locationDetails}</span>
+          </div>
+          <div className="flex grow flex-col gap-y-4 font-semibold">
+            <span>Total</span>
+            <span>Audio</span>
+            <span>Subtitles</span>
+          </div>
+          <div className="flex max-w-[60%] grow-[2] flex-col gap-y-4">
+            <span>{sizes}</span>
+            <span>{audioDetails}</span>
+            <span>{subtitleDetails}</span>
+          </div>
+        </div>
       </div>
-      <div className="flex">
-        <div className="flex grow flex-col gap-y-4 font-semibold">
-          <span>Group</span>
-          <span>Video</span>
-          <span>Location</span>
-        </div>
-        <div className="flex grow-[2] flex-col gap-y-4">
-          <span>{groupDetails}</span>
-          <span>{videoDetails}</span>
-          <span>{locationDetails}</span>
-        </div>
-        <div className="flex grow flex-col gap-y-4 font-semibold">
-          <span>Total</span>
-          <span>Audio</span>
-          <span>Subtitles</span>
-        </div>
-        <div className="flex grow-[2] flex-col gap-y-4">
-          <span>{sizes}</span>
-          <span>{audioDetails}</span>
-          <span>{subtitleDetails}</span>
-        </div>
-      </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 type FileSelectionHeaderProps = {
   mode: ModeType;
@@ -354,7 +359,7 @@ const SeriesFileSummary = () => {
     }
   });
 
-  const { data: fileSummary, isLoading } = useSeriesFileSummaryQuery(
+  const { data: fileSummary, isFetching, isLoading } = useSeriesFileSummaryQuery(
     toNumber(seriesId!),
     { groupBy: filter.join(',') },
     !!seriesId,
@@ -413,7 +418,10 @@ const SeriesFileSummary = () => {
             </div>
           )}
           {mode === 'Series'
-            && map(fileSummary?.Groups, (range, idx) => <SummaryGroup key={`group-${idx}`} group={range} />)}
+            && map(
+              fileSummary?.Groups,
+              (range, idx) => <SummaryGroup key={`group-${idx}`} group={range} fetchingState={isFetching} />,
+            )}
           {mode === 'Missing' && <MissingEpisodes missingEps={fileSummary?.MissingEpisodes} />}
         </div>
       </div>


### PR DESCRIPTION
This should fix layout jumping while new query results are being fetched in the summary page. A loading indicator is shown in the header for each group of results, so in the event of a slow response, it should be clear that the data is currently updating.

There's probably a better way to go about this, but this was the best I could find in the tanstack documentation quickly!


I will do a follow up PR to rebase all the changes thus far on top of `ShokoServer-WebUI/master` once/if this has been merged.